### PR TITLE
Add Mapbox Settings, Update Mapbox API to v4, Add Custom Map Tiles

### DIFF
--- a/controllers/admin/mapbox_settings.php
+++ b/controllers/admin/mapbox_settings.php
@@ -1,0 +1,60 @@
+<?php defined('SYSPATH') or die('No direct script access.');
+/**
+ * Mapbox Settings Controller
+ *
+ * PHP version 5
+ * LICENSE: This source file is subject to LGPL license
+ * that is available through the world-wide-web at the following URI:
+ * http://www.gnu.org/copyleft/lesser.html
+ * @author	   Ushahidi Team <team@ushahidi.com>
+ * @package    Ushahidi - http://source.ushahididev.com
+ * @module	   Clickatell Settings Controller
+ * @copyright  Ushahidi - http://www.ushahidi.com
+ * @license    http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License (LGPL)
+*
+*/
+
+class Mapbox_Settings_Controller extends Admin_Controller {
+	public function index()
+	{
+		$this->template->this_page = 'addons';
+
+		// Standard Settings View
+		$this->template->content = new View("admin/addons/plugin_settings");
+		$this->template->content->title = "Mapbox Settings";
+
+		// Settings Form View
+		$this->template->content->settings_form = new View("mapbox/admin/mapbox_settings");
+
+		// Do we have a frontlineSMS Key? If not create and save one on the fly
+		$mapbox = ORM::factory('mapbox', 1);
+
+		// Get current settings.
+		if (!$mapbox->loaded) {
+			// We don't have a settings row for this, so create a blank one.
+			$mapbox->id = 1;
+			$mapbox->save();
+		}
+
+		if ($_POST) {
+			// Instantiate Validation, use $post, so we don't overwrite $_POST
+			// fields with our own things
+			$post = new Validation($_POST);
+
+			// Add some filters
+			$post->pre_filter('trim', TRUE);
+
+			$post->add_rules('mapbox_access_token', 'required');
+			$post->add_rules('mapbox_map_id','required');
+
+			if ($post->validate()) {
+				$mapbox->mapbox_access_token = $post->mapbox_access_token;
+				$mapbox->mapbox_map_id       = $post->mapbox_map_id;
+				$mapbox->save();
+			}
+		}
+
+		$this->template->content->settings_form->mapbox_access_token = $mapbox->mapbox_access_token;
+		$this->template->content->settings_form->mapbox_map_id       = $mapbox->mapbox_map_id;
+	}
+}

--- a/hooks/mapbox.php
+++ b/hooks/mapbox.php
@@ -3,28 +3,28 @@
  * Mapbox Hook - Load All Events
  *
  * PHP version 5
- * LICENSE: This source file is subject to LGPL license 
+ * LICENSE: This source file is subject to LGPL license
  * that is available through the world-wide-web at the following URI:
  * http://www.gnu.org/copyleft/lesser.html
- * @author	   Ushahidi Team <team@ushahidi.com> 
+ * @author	   Ushahidi Team <team@ushahidi.com>
  * @package	   Ushahidi - http://source.ushahididev.com
  * @copyright  Ushahidi - http://www.ushahidi.com
- * @license	   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License (LGPL) 
+ * @license	   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License (LGPL)
  */
 
 class mapbox {
-	
+
 	private $layers;
-	
+
 	/**
 	 * Registers the main event add method
 	 */
 	public function __construct()
-	{		
+	{
 		// Hook into routing
 		Event::add('system.pre_controller', array($this, 'add'));
 	}
-	
+
 	/**
 	 * Adds all the events to the main Ushahidi application
 	 */
@@ -36,90 +36,52 @@ class mapbox {
 			Event::add('ushahidi_filter.map_layers_js', array($this, '_add_map_layers_js'));
 		}
 	}
-	
+
 	public function _add_layer()
 	{
 		$this->layers = Event::$data;
 		$this->layers = $this->_create_layer();
-		
+
 		// Return layers object with new Cloudmade Layer
 		Event::$data = $this->layers;
 	}
-	
+
 	public function _create_layer()
 	{
 
-		// MapBoxStreets
+		// Do we have a frontlineSMS Key? If not create and save one on the fly
+		$mapbox = ORM::factory('mapbox', 1);
+
+		// Get current settings.
+		if (!$mapbox->loaded) {
+			// We don't have a settings row for this, so create a blank one.
+			$mapbox->id = 1;
+			$mapbox->save();
+		}
+
+		// Custom Mapbox Tiles
 		$layer = new stdClass();
 		$layer->active = TRUE;
-		$layer->name = 'mapbox_streets';
+		$layer->name = 'mapbox_custom';
 		$layer->openlayers = "XYZ";
-		$layer->title = 'Mapbox Streets';
+		$layer->title = 'Mapbox Custom Tiles';
 		$layer->description = '.';
 		$layer->api_url = '';
 		$layer->data = array(
 			'baselayer' => TRUE,
 			'attribution' => '',
-			'url' => 'http://a.tiles.mapbox.com/v3/mapbox.mapbox-streets/${z}/${x}/${y}.png',
+			'url' => 'http://a.tiles.mapbox.com/v4/'.$mapbox->mapbox_map_id.'/${z}/${x}/${y}.png?access_token='.$mapbox->mapbox_access_token,
 			'type' => ''
 		);
 		$this->layers[$layer->name] = $layer;
 
-		// MapBoxStreets - Lacquer
-		$layer = new stdClass();
-		$layer->active = TRUE;
-		$layer->name = 'mapbox_lacquer';
-		$layer->openlayers = "XYZ";
-		$layer->title = 'Mapbox Lacquer';
-		$layer->description = '.';
-		$layer->api_url = '';
-		$layer->data = array(
-			'baselayer' => TRUE,
-			'attribution' => '',
-			'url' => 'http://a.tiles.mapbox.com/v3/mapbox.mapbox-lacquer/${z}/${x}/${y}.png',
-			'type' => ''
-		);
-		$this->layers[$layer->name] = $layer;
-
-		// MapBoxStreets - Light
-		$layer = new stdClass();
-		$layer->active = TRUE;
-		$layer->name = 'mapbox_light';
-		$layer->openlayers = "XYZ";
-		$layer->title = 'Mapbox Light';
-		$layer->description = '.';
-		$layer->api_url = '';
-		$layer->data = array(
-			'baselayer' => TRUE,
-			'attribution' => '',
-			'url' => 'http://a.tiles.mapbox.com/v3/mapbox.mapbox-light/${z}/${x}/${y}.png',
-			'type' => ''
-		);
-		$this->layers[$layer->name] = $layer;
-
-		// MapBoxStreets - Simple
-		$layer = new stdClass();
-		$layer->active = TRUE;
-		$layer->name = 'mapbox_simple';
-		$layer->openlayers = "XYZ";
-		$layer->title = 'Mapbox Simple';
-		$layer->description = '.';
-		$layer->api_url = '';
-		$layer->data = array(
-			'baselayer' => TRUE,
-			'attribution' => '',
-			'url' => 'http://a.tiles.mapbox.com/v3/mapbox.mapbox-simple/${z}/${x}/${y}.png',
-			'type' => ''
-		);
-		$this->layers[$layer->name] = $layer;
-		
 		return $this->layers;
 	}
 
 	function _add_map_layers_js ()
 	{
 		$js = Event::$data;
-		
+
 		// Next get the default base layer
 		$default_map = Kohana::config('settings.default_map');
 

--- a/libraries/mapbox_install.php
+++ b/libraries/mapbox_install.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Performs install/uninstall methods for the Mapbox plugin
+ *
+ * PHP version 5
+ * LICENSE: This source file is subject to LGPL license
+ * that is available through the world-wide-web at the following URI:
+ * http://www.gnu.org/copyleft/lesser.html
+ * @author	   Ushahidi Team <team@ushahidi.com>
+ * @package    Ushahidi - http://source.ushahididev.com
+ * @module	   Actionable Installer
+ * @copyright  Ushahidi - http://www.ushahidi.com
+ * @license    http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License (LGPL)
+ */
+
+class Mapbox_Install {
+
+	/**
+	 * Constructor to load the shared database library
+	 */
+	public function __construct()
+	{
+		$this->db = Database::instance();
+	}
+
+	/**
+	 * Creates the required database tables for the Mapbox plugin
+	 */
+	public function run_install()
+	{
+		// Create the database tables.
+		// Also include table_prefix in name
+		$this->db->query('CREATE TABLE `'.Kohana::config('database.default.table_prefix').'mapbox` (
+			  `id` int(11) unsigned NOT NULL,
+			  `mapbox_access_token` varchar(255) DEFAULT NULL,
+			  `mapbox_map_id` varchar(255) DEFAULT NULL,
+			  PRIMARY KEY (`id`)
+			) ENGINE=InnoDB DEFAULT CHARSET=utf8;');
+	}
+
+	/**
+	 * Deletes the database tables for the Mapbox module
+	 */
+	public function uninstall()
+	{
+		$this->db->query('DROP TABLE `'.Kohana::config('database.default.table_prefix').'mapbox`;');
+	}
+
+}

--- a/models/mapbox.php
+++ b/models/mapbox.php
@@ -1,0 +1,21 @@
+<?php defined('SYSPATH') or die('No direct script access.');
+/**
+ * Mapbox Model
+ *
+ * PHP version 5
+ * LICENSE: This source file is subject to LGPL license
+ * that is available through the world-wide-web at the following URI:
+ * http://www.gnu.org/copyleft/lesser.html
+ * @author     Ushahidi Team <team@ushahidi.com>
+ * @package    Ushahidi - http://source.ushahididev.com
+ * @module     FrontlineSMS Model
+ * @copyright  Ushahidi - http://www.ushahidi.com
+ * @license    http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License (LGPL)
+ */
+
+class Mapbox_Model extends ORM
+{
+
+	// Database table name
+	protected $table_name = 'mapbox';
+}

--- a/views/mapbox/admin/mapbox_settings.php
+++ b/views/mapbox/admin/mapbox_settings.php
@@ -1,0 +1,26 @@
+<table style="width: 630px;" class="my_table">
+	<tr>
+		<td>
+			<span class="big_blue_span"><?php echo Kohana::lang('ui_main.step');?> 1:</span>
+			<p>
+				Create a public access token on your Mapbox account. If you need help, follow support from Mapbox: <a href="https://www.mapbox.com/help/create-api-access-token/">How do I create an API access token?</a>
+			</p>
+		</td>
+		<td>
+			<h4 class="fix">Public Access Token:</h4>
+			<?php print form::input('mapbox_access_token', $mapbox_access_token, ' class="text title_2"'); ?>
+		</td>
+	</tr>
+	<tr>
+		<td>
+			<span class="big_blue_span"><?php echo Kohana::lang('ui_main.step');?> 2:</span>
+			<p>
+				Your map ID is the ID that uniquely identifies your Mapbox map. If you need help, follow support from Mapbox: <a href="https://www.mapbox.com/help/define-map-id/">What is a map ID?</a>
+			</p>
+		</td>
+		<td>
+			<h4 class="fix">Map ID:</h4>
+			<?php print form::input('mapbox_map_id', $mapbox_map_id, ' class="text title_2"'); ?>
+		</td>
+	</tr>
+</table>


### PR DESCRIPTION
Before this commit, it wasn't possible to use this plugin anymore due to changes to the API at Mapbox. This allows the deployer to save their public Mapbox access token and configure the plugin to use any map they create on Mapbox as their baselayer using the Map ID.

This could clearly be taken many steps further but this feels sufficient at this time.
